### PR TITLE
Fixed line endings with normalization.

### DIFF
--- a/src/dictim/d2/parse.cljc
+++ b/src/dictim/d2/parse.cljc
@@ -8,7 +8,7 @@
             [dictim.utils :refer [error try-parse-primitive]]))
 
 ;; Define a function to normalize line endings
-(defn normalize-line-endings [s]
+(defn- normalize-line-endings [s]
   (str/replace s #"\r\n" "\n"))
 
 ;; d2 parser v2

--- a/src/dictim/d2/parse.cljc
+++ b/src/dictim/d2/parse.cljc
@@ -7,6 +7,10 @@
             [dictim.d2.attributes :as at]
             [dictim.utils :refer [error try-parse-primitive]]))
 
+;; Define a function to normalize line endings
+(defn normalize-line-endings [s]
+  (str/replace s #"\r\n" "\n"))
+
 ;; d2 parser v2
 
 ;; This rewrite of the parser focuses on good future extensibility. To support that;
@@ -286,7 +290,8 @@
               label-fn str/trim
               flatten-lists? false
               retain-empty-lines? false}}]
-  (let [p-trees (parse-d2 d2)
+  (let [normalized-d2 (normalize-line-endings d2) ;; Normalize line endings
+        p-trees (parse-d2 normalized-d2)
         key-fn (comp key-fn str/trim)
         with-tag (fn [obj tag] (with-meta obj {:tag tag}))
         process-empty-lines (fn [parts]
@@ -303,6 +308,7 @@
 
                                    :else                              false))
                                parts))]
+
     (if (insta/failure? p-trees)
       (throw (error (str "Could not parse: " (:text p-trees))))
       (mapcat


### PR DESCRIPTION
Test result for Windows 11.

Eddie@LZXTH1 MINGW64 ~/OneDrive/Dev/git/dictim (fix-line-ends)
$ clj -X:test

Running tests in #{"test"}

Testing dictim.d2.compile-test

Testing dictim.d2.parse-test

Testing dictim.flat-test

Testing dictim.graphspec-test

Testing dictim.json-test

Testing dictim.template-test

Ran 83 tests containing 361 assertions.
0 failures, 0 errors.

Eddie@LZXTH1 MINGW64 ~/OneDrive/Dev/git/dictim (fix-line-ends)
